### PR TITLE
Add brew install smoke test to CI

### DIFF
--- a/.github/workflows/homebrew-update-cf-purge.yml
+++ b/.github/workflows/homebrew-update-cf-purge.yml
@@ -66,6 +66,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add cf-purge.rb
+          git diff --cached --quiet && echo "No changes to commit" && exit 0
           git commit -m "Update formula to ${{ steps.get_release.outputs.tag }}"
           git push
 

--- a/.github/workflows/homebrew-update-cf-purge.yml
+++ b/.github/workflows/homebrew-update-cf-purge.yml
@@ -14,9 +14,6 @@ permissions:
 jobs:
   update-formula:
     runs-on: ubuntu-latest
-    outputs:
-      formula-updated: ${{ steps.update_check.outputs.updated }}
-      tag: ${{ steps.get_release.outputs.tag }}
     steps:
       - name: Checkout tap repo
         uses: actions/checkout@v4
@@ -47,7 +44,6 @@ jobs:
           echo "sha256=$SHA256" >> $GITHUB_OUTPUT
 
       - name: Update cf-purge.rb
-        id: update_formula
         run: |
           sed -i.bak "s|url \".*\"|url \"${{ steps.get_release.outputs.url }}\"|" cf-purge.rb
           sed -i.bak "s|sha256 \".*\"|sha256 \"${{ steps.sha.outputs.sha256 }}\"|" cf-purge.rb
@@ -57,43 +53,39 @@ jobs:
         id: update_check
         run: |
           if git diff --quiet cf-purge.rb; then
-            echo "updated=false" >> $GITHUB_OUTPUT
             echo "No changes to formula"
+            exit 0
           else
-            echo "updated=true" >> $GITHUB_OUTPUT
             echo "Formula updated"
           fi
 
+      - name: Commit and push changes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add cf-purge.rb
+          git commit -m "Update formula to ${{ steps.get_release.outputs.tag }}"
+          git push
+
   smoke-test:
     needs: update-formula
-    if: needs.update-formula.outputs.formula-updated == 'true'
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout tap repo
-        uses: actions/checkout@v4
-
       - name: Setup Homebrew
         uses: Homebrew/actions/setup-homebrew@master
 
       - name: Install Go
         run: brew install go
 
-      - name: Apply formula updates
+      - name: Add this tap
         run: |
-          # Apply the same updates that were made in the update-formula job
-          curl -s https://api.github.com/repos/Dzhuneyt/cf-purge/releases/latest > release.json
-          TAG=$(jq -r .tag_name release.json)
-          TARBALL_URL=$(jq -r '.tarball_url' release.json)
-          
-          curl -L "$TARBALL_URL" -o asset.tar.gz
-          SHA256=$(shasum -a 256 asset.tar.gz | awk '{print $1}')
-          
-          sed -i.bak "s|url \".*\"|url \"$TARBALL_URL\"|" cf-purge.rb
-          sed -i.bak "s|sha256 \".*\"|sha256 \"$SHA256\"|" cf-purge.rb
+          brew tap ${{ github.repository }}
 
-      - name: Install cf-purge from local formula
+      - name: Install cf-purge
         run: |
-          brew install ./cf-purge.rb
+          brew install cf-purge
 
       - name: Verify cf-purge installation
         run: |
@@ -116,34 +108,3 @@ jobs:
           fi
           
           echo "✅ Smoke test passed: cf-purge installed and working correctly"
-
-  commit-changes:
-    needs: [update-formula, smoke-test]
-    if: needs.update-formula.outputs.formula-updated == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout tap repo
-        uses: actions/checkout@v4
-
-      - name: Apply formula updates
-        run: |
-          # Apply the same updates that were made in the update-formula job
-          curl -s https://api.github.com/repos/Dzhuneyt/cf-purge/releases/latest > release.json
-          TAG=$(jq -r .tag_name release.json)
-          TARBALL_URL=$(jq -r '.tarball_url' release.json)
-          
-          curl -L "$TARBALL_URL" -o asset.tar.gz
-          SHA256=$(shasum -a 256 asset.tar.gz | awk '{print $1}')
-          
-          sed -i.bak "s|url \".*\"|url \"$TARBALL_URL\"|" cf-purge.rb
-          sed -i.bak "s|sha256 \".*\"|sha256 \"$SHA256\"|" cf-purge.rb
-
-      - name: Commit and push changes
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add cf-purge.rb
-          git commit -m "Update formula to ${{ needs.update-formula.outputs.tag }}"
-          git push

--- a/.github/workflows/homebrew-update-cf-purge.yml
+++ b/.github/workflows/homebrew-update-cf-purge.yml
@@ -49,16 +49,6 @@ jobs:
           sed -i.bak "s|sha256 \".*\"|sha256 \"${{ steps.sha.outputs.sha256 }}\"|" cf-purge.rb
           cat cf-purge.rb
 
-      - name: Check if formula was updated
-        id: update_check
-        run: |
-          if git diff --quiet cf-purge.rb; then
-            echo "No changes to formula"
-            exit 0
-          else
-            echo "Formula updated"
-          fi
-
       - name: Commit and push changes
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/homebrew-update-cf-purge.yml
+++ b/.github/workflows/homebrew-update-cf-purge.yml
@@ -14,6 +14,9 @@ permissions:
 jobs:
   update-formula:
     runs-on: ubuntu-latest
+    outputs:
+      formula-updated: ${{ steps.update_check.outputs.updated }}
+      tag: ${{ steps.get_release.outputs.tag }}
     steps:
       - name: Checkout tap repo
         uses: actions/checkout@v4
@@ -44,10 +47,96 @@ jobs:
           echo "sha256=$SHA256" >> $GITHUB_OUTPUT
 
       - name: Update cf-purge.rb
+        id: update_formula
         run: |
           sed -i.bak "s|url \".*\"|url \"${{ steps.get_release.outputs.url }}\"|" cf-purge.rb
           sed -i.bak "s|sha256 \".*\"|sha256 \"${{ steps.sha.outputs.sha256 }}\"|" cf-purge.rb
           cat cf-purge.rb
+
+      - name: Check if formula was updated
+        id: update_check
+        run: |
+          if git diff --quiet cf-purge.rb; then
+            echo "updated=false" >> $GITHUB_OUTPUT
+            echo "No changes to formula"
+          else
+            echo "updated=true" >> $GITHUB_OUTPUT
+            echo "Formula updated"
+          fi
+
+  smoke-test:
+    needs: update-formula
+    if: needs.update-formula.outputs.formula-updated == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout tap repo
+        uses: actions/checkout@v4
+
+      - name: Setup Homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+
+      - name: Install Go
+        run: brew install go
+
+      - name: Apply formula updates
+        run: |
+          # Apply the same updates that were made in the update-formula job
+          curl -s https://api.github.com/repos/Dzhuneyt/cf-purge/releases/latest > release.json
+          TAG=$(jq -r .tag_name release.json)
+          TARBALL_URL=$(jq -r '.tarball_url' release.json)
+          
+          curl -L "$TARBALL_URL" -o asset.tar.gz
+          SHA256=$(shasum -a 256 asset.tar.gz | awk '{print $1}')
+          
+          sed -i.bak "s|url \".*\"|url \"$TARBALL_URL\"|" cf-purge.rb
+          sed -i.bak "s|sha256 \".*\"|sha256 \"$SHA256\"|" cf-purge.rb
+
+      - name: Install cf-purge from local formula
+        run: |
+          brew install ./cf-purge.rb
+
+      - name: Verify cf-purge installation
+        run: |
+          # Test that the binary exists and is executable
+          if [ ! -f "$(brew --prefix)/bin/cf-purge" ]; then
+            echo "Error: cf-purge binary not found in expected location"
+            exit 1
+          fi
+          
+          # Test that --help works
+          if ! cf-purge --help > /dev/null 2>&1; then
+            echo "Error: cf-purge --help command failed"
+            exit 1
+          fi
+          
+          # Verify help output contains expected content
+          if ! cf-purge --help | grep -q "cf-purge"; then
+            echo "Error: cf-purge --help output doesn't contain expected content"
+            exit 1
+          fi
+          
+          echo "✅ Smoke test passed: cf-purge installed and working correctly"
+
+  commit-changes:
+    needs: [update-formula, smoke-test]
+    if: needs.update-formula.outputs.formula-updated == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout tap repo
+        uses: actions/checkout@v4
+
+      - name: Apply formula updates
+        run: |
+          # Apply the same updates that were made in the update-formula job
+          curl -s https://api.github.com/repos/Dzhuneyt/cf-purge/releases/latest > release.json
+          TAG=$(jq -r .tag_name release.json)
+          TARBALL_URL=$(jq -r '.tarball_url' release.json)
+          
+          curl -L "$TARBALL_URL" -o asset.tar.gz
+          SHA256=$(shasum -a 256 asset.tar.gz | awk '{print $1}')
+          
+          sed -i.bak "s|url \".*\"|url \"$TARBALL_URL\"|" cf-purge.rb
+          sed -i.bak "s|sha256 \".*\"|sha256 \"$SHA256\"|" cf-purge.rb
 
       - name: Commit and push changes
         env:
@@ -56,6 +145,5 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add cf-purge.rb
-          git diff --cached --quiet && echo "No changes to commit" && exit 0
-          git commit -m "Update formula to ${{ steps.get_release.outputs.tag }}"
+          git commit -m "Update formula to ${{ needs.update-formula.outputs.tag }}"
           git push


### PR DESCRIPTION
Add a smoke test to the Homebrew update workflow to verify successful `brew install` and `cf-purge --help` execution before committing formula updates.

---
<a href="https://cursor.com/background-agent?bcId=bc-fabfd003-0ce5-41ec-b94a-bc5f6c8f1cff">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fabfd003-0ce5-41ec-b94a-bc5f6c8f1cff">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

