### PR TITLE
Fix brew tap command in github action

### DIFF
--- a/.github/workflows/homebrew-update-cf-purge.yml
+++ b/.github/workflows/homebrew-update-cf-purge.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Add this tap
         run: |
-          brew tap ${{ github.repository }}
+          brew tap ${{ github.repository_owner }}/tap
 
       - name: Install cf-purge
         run: |


### PR DESCRIPTION
Fix `brew tap` command in smoke-test workflow to use the correct owner/tap format.

---
<a href="https://cursor.com/background-agent?bcId=bc-c42edaaa-694e-49fc-a176-f6f6f43555c1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c42edaaa-694e-49fc-a176-f6f6f43555c1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

